### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ __send simple email__
 ``` js
   'use strict';
   const nodemailer = require('nodemailer');
-  const MandrillTransport = require('mandrill-nodemailer-transport');
+  const mandrill_nodemailer = require('mandrill-nodemailer-transport');
 
-  let transporter = nodemailer.createTransport(new MandrillTransport({
+  let transporter = nodemailer.createTransport(new mandrill_nodemailer.MandrillTransport({
     apiKey: '12124124124124-key-test'
   }));
 
@@ -49,9 +49,9 @@ __send attachment and add to content__
 ``` js
   'use strict';
   const nodemailer = require('nodemailer');
-  const MandrillTransport = require('mandrill-nodemailer-transport');
+  const mandrill_nodemailer = require('mandrill-nodemailer-transport');
 
-  let transporter = nodemailer.createTransport(new MandrillTransport({
+  let transporter = nodemailer.createTransport(new mandrill_nodemailer.MandrillTransport({
     apiKey: '12124124124124-key-test'
   }));
 


### PR DESCRIPTION
The example is wrong. If I try to execute the example nodejs says that MandrillTransport is not a constructor. That is caused because the require() statement import the whole library not the constructor.